### PR TITLE
fixes menus reducer

### DIFF
--- a/src/actions/session/menus.js
+++ b/src/actions/session/menus.js
@@ -23,5 +23,7 @@ export const fetchMenu = (brandibble, menuType = defaultMenuType) => (dispatch) 
   const payload = brandibble.menus.build(locationId, serviceType, requestedAtFormatted)
     .then(({ data }) => data).catch(handleErrors);
 
-  return dispatch(fireAction(FETCH_MENU, payload));
+  const meta = { menuKey: `${locationId}_${requestedAt}_${serviceType}` };
+
+  return dispatch(fireAction(FETCH_MENU, payload, meta));
 };

--- a/src/actions/session/menus.js
+++ b/src/actions/session/menus.js
@@ -23,7 +23,7 @@ export const fetchMenu = (brandibble, menuType = defaultMenuType) => (dispatch) 
   const payload = brandibble.menus.build(locationId, serviceType, requestedAtFormatted)
     .then(({ data }) => data).catch(handleErrors);
 
-  const meta = { menuKey: `${locationId}_${requestedAt}_${serviceType}` };
+  const meta = { menuKey: `${locationId}_${serviceType}_${requestedAt}` };
 
   return dispatch(fireAction(FETCH_MENU, payload, meta));
 };

--- a/src/reducers/session/menus.js
+++ b/src/reducers/session/menus.js
@@ -3,13 +3,13 @@ import { FETCH_MENU } from '../../actions/session/menus';
 const initialState = {};
 
 export default (state = initialState, action) => {
-  const { type, payload } = action;
+  const { type, payload, meta } = action;
 
   switch (type) {
     case `${FETCH_MENU}_FULFILLED`:
       return {
         ...state,
-        [`${payload.id}`]: payload,
+        [meta.menuKey]: payload,
       };
     default:
       return state;

--- a/src/utils/fireAction.js
+++ b/src/utils/fireAction.js
@@ -1,3 +1,3 @@
-export default (type, payload) => {
-  return { type, payload };
+export default (type, payload, meta) => {
+  return { type, payload, meta };
 };

--- a/tests/actions/session/menus.test.js
+++ b/tests/actions/session/menus.test.js
@@ -41,7 +41,7 @@ describe('actions/session/menus', () => {
         action = find(actionsCalled, { type: `${FETCH_MENU}_FULFILLED` });
         expect(action).to.exist;
         expect(action).to.have.property('meta');
-        expect(action.meta).to.have.property('menuKey', `${menuType.locationId}_${menuType.requestedAt}_${menuType.serviceType}`);
+        expect(action.meta).to.have.property('menuKey', `${menuType.locationId}_${menuType.serviceType}_${menuType.requestedAt}`);
       });
     });
   });

--- a/tests/actions/session/menus.test.js
+++ b/tests/actions/session/menus.test.js
@@ -11,12 +11,19 @@ const mockStore = configureStore(reduxMiddleware);
 
 describe('actions/session/menus', () => {
   describe('fetchMenu', () => {
-    let store, actionsCalled, action;
+    let store, actionsCalled, action, menuType;
 
     describe('calls actions', () => {
       before(() => {
         store = mockStore();
-        return fetchMenu(brandibble, { locationId: SAMPLE_MENU_LOCATION_ID })(store.dispatch).then(() => {
+
+        menuType = {
+          locationId: SAMPLE_MENU_LOCATION_ID,
+          requestedAt: 1,
+          serviceType: 'delivery',
+        };
+
+        return fetchMenu(brandibble, menuType)(store.dispatch).then(() => {
           actionsCalled = store.getActions();
         });
       });
@@ -33,6 +40,8 @@ describe('actions/session/menus', () => {
       it(`should have ${FETCH_MENU}_FULFILLED action`, () => {
         action = find(actionsCalled, { type: `${FETCH_MENU}_FULFILLED` });
         expect(action).to.exist;
+        expect(action).to.have.property('meta');
+        expect(action.meta).to.have.property('menuKey', `${menuType.locationId}_${menuType.requestedAt}_${menuType.serviceType}`);
       });
     });
   });

--- a/tests/config/stubs.js
+++ b/tests/config/stubs.js
@@ -171,6 +171,10 @@ export const menusStub = {
   ],
 };
 
+export const menuMetaStub = {
+  menuKey: 'testKey',
+};
+
 export const locationsStub = [
   {
     city: 'Rye Brook',

--- a/tests/reducers/application.test.js
+++ b/tests/reducers/application.test.js
@@ -6,7 +6,7 @@ import { FETCH_GEOLOCATIONS } from 'actions/data/geolocations';
 import { FETCH_MENU } from 'actions/session/menus';
 import { VALIDATE_USER } from 'actions/session/user';
 import { RESET_APPLICATION } from 'actions/application';
-import { locationsStub, menusStub, customersValidateStub } from '../config/stubs';
+import { locationsStub, menusStub, menuMetaStub, customersValidateStub } from '../config/stubs';
 
 const store = createStore(rootReducer);
 const initialState = store.getState();
@@ -20,6 +20,7 @@ describe('application reducers', () => {
     store.dispatch({
       type: `${FETCH_MENU}_FULFILLED`,
       payload: menusStub,
+      meta: menuMetaStub,
     });
     store.dispatch({
       type: `${VALIDATE_USER}_FULFILLED`,

--- a/tests/reducers/session/menus.test.js
+++ b/tests/reducers/session/menus.test.js
@@ -2,10 +2,11 @@
 import { expect } from 'chai';
 import reducer from 'reducers/session/menus';
 import { FETCH_MENU } from 'actions/session/menus';
-import { menusStub } from '../../config/stubs';
+import { menusStub, menuMetaStub } from '../../config/stubs';
 
 const initialState = {};
 const payload = menusStub;
+const meta = menuMetaStub;
 
 describe('reducers/session/menus', () => {
   it('should return the initial state', () => {
@@ -16,7 +17,8 @@ describe('reducers/session/menus', () => {
     const reduced = reducer(initialState, {
       type: `${FETCH_MENU}_FULFILLED`,
       payload,
+      meta,
     });
-    expect(reduced[payload.id]).to.equal(payload);
+    expect(reduced[meta.menuKey]).to.equal(payload);
   });
 });


### PR DESCRIPTION
The menus reducer was keying fetched menus as ```undefined``` because the id key did not exist on the payload. 

We are now keying menus using the params used to request the menu.