### PR TITLE
coerces requested at to iso8601 to ensure easier menu find

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Sanctuary Computer <hello@sanctuary.computer> (http://sanctuary.computer/)",
   "license": "MIT",
   "dependencies": {
-    "brandibble": "git+https://git@github.com/sanctuarycomputer/brandibble.js#a39d6e41587fe844f2a711d5a9d4c1a5521edafc",
+    "brandibble": "git+https://git@github.com/sanctuarycomputer/brandibble.js#63000e859ea4990ab3bcea24101b1ef968d853b9",
     "localforage": "^1.5.0",
     "lodash.filter": "^4.6.0",
     "lodash.find": "^4.6.0",

--- a/src/actions/session/menus.js
+++ b/src/actions/session/menus.js
@@ -1,8 +1,10 @@
+import { utils } from 'brandibble';
 import fireAction from '../../utils/fireAction';
 import handleErrors from '../../utils/handleErrors';
 
 export const FETCH_MENU = 'FETCH_MENU';
 
+const { coerceDateToISO8601 } = utils;
 const NOW = new Date();
 
 const defaultMenuType = {
@@ -17,12 +19,16 @@ export const fetchMenu = (
 ) => (dispatch) => {
   const { locationId, requestedAt, serviceType } = menuType;
 
+  const requestedAtAsISO8601 = coerceDateToISO8601(requestedAt);
+
   const payload = brandibble.menus
-    .build(locationId, serviceType, requestedAt)
+    .build(locationId, serviceType, requestedAtAsISO8601)
     .then(({ data }) => data)
     .catch(handleErrors);
 
-  const meta = { menuKey: `${locationId}_${serviceType}_${requestedAt}` };
+  const meta = {
+    menuKey: `${locationId}_${serviceType}_${requestedAtAsISO8601}`,
+  };
 
   return dispatch(fireAction(FETCH_MENU, payload, meta));
 };

--- a/tests/actions/session/menus.test.js
+++ b/tests/actions/session/menus.test.js
@@ -2,11 +2,13 @@
 /* eslint one-var-declaration-per-line:1, one-var:1 */
 import { expect } from 'chai';
 import find from 'lodash.find';
+import { utils } from 'brandibble';
 import configureStore from 'redux-mock-store';
 import reduxMiddleware from 'config/middleware';
 import { fetchMenu, FETCH_MENU } from 'actions/session/menus';
 import { brandibble, SAMPLE_MENU_LOCATION_ID } from '../../config/stubs';
 
+const { coerceDateToISO8601 } = utils;
 const mockStore = configureStore(reduxMiddleware);
 
 describe('actions/session/menus', () => {
@@ -46,9 +48,9 @@ describe('actions/session/menus', () => {
         expect(action).to.have.property('meta');
         expect(action.meta).to.have.property(
           'menuKey',
-          `${menuType.locationId}_${menuType.serviceType}_${
-            menuType.requestedAt
-          }`,
+          `${menuType.locationId}_${menuType.serviceType}_${coerceDateToISO8601(
+            menuType.requestedAt,
+          )}`,
         );
       });
     });


### PR DESCRIPTION
Previously, menu keys in redux could have the requestedt_at suffix either as a JS Date or ISO8601 datetime string. This makes things difficult when attempting to retrieve the most recent menu, as you couldn't reliably use the order's requested_at to fetch the most recent menu.

This is failing because it's reliant on the following Brandibble PR. https://github.com/BetterBOH/brandibble.js/pull/176