### PR TITLE
250 update validate current cart

### DIFF
--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -502,6 +502,7 @@ export function setOrderLocationId(
     const state = getStateWithNamespace(getState);
     const cart = get(state, 'session.order.orderData.cart', []);
     const hasItemsInCart = !!cart && cart.length;
+
     if (
       hasItemsInCart &&
       (onValidationError && typeof onValidationError === 'function')
@@ -509,6 +510,7 @@ export function setOrderLocationId(
       /**
        * apiVersion: v2
        */
+
       if (get(validateOptions, 'apiVersion') === ApiVersion.V2) {
         return dispatch(
           _v2_withCartValidation(
@@ -994,7 +996,7 @@ function _v2_withCartValidation(
     const ref = get(state, 'ref');
     const { orders } = ref;
     const order = orders.current();
-    const callback =
+    const callback = () =>
       !!actionCallback && typeof actionCallback === 'function'
         ? dispatch(actionCallback())
         : Promise.resolve();
@@ -1021,7 +1023,7 @@ function _v2_withCartValidation(
          * If the validation succeeds
          * we dispatch the actionCallback
          */
-        .then(callback)
+        .then(() => callback())
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1060,7 +1062,7 @@ function _v2_withCartValidation(
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(callback);
+                return Promise.all(promises).then(() => callback());
               }
 
               /**
@@ -1097,7 +1099,7 @@ function _v2_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(callback);
+                  ).then(() => callback());
                 }
 
                 /**
@@ -1124,7 +1126,7 @@ function _v2_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(callback);
+                  ).then(() => callback());
                 });
               }
 
@@ -1165,7 +1167,7 @@ function _v1_withCartValidation(
     const ref = get(state, 'ref');
     const { orders } = ref;
     const order = orders.current();
-    const callback =
+    const callback = () =>
       !!actionCallback && typeof actionCallback === 'function'
         ? dispatch(actionCallback())
         : Promise.resolve();
@@ -1194,7 +1196,7 @@ function _v1_withCartValidation(
          * Otherwise we return null (this is necessary in the case that
          * validateCurrentCart is passed an onValidationError callback)
          */
-        .then(callback)
+        .then(() => callback())
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1229,7 +1231,7 @@ function _v1_withCartValidation(
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(callback);
+                return Promise.all(promises).then(() => callback());
               }
 
               /**
@@ -1266,7 +1268,7 @@ function _v1_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(callback);
+                  ).then(() => callback());
                 }
 
                 /**
@@ -1293,7 +1295,7 @@ function _v1_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(callback);
+                  ).then(() => callback());
                 });
               }
 

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -6,6 +6,7 @@ import {
   Asap,
   ErrorCodes,
   WantsFutureReasons,
+  ApiVersions,
 } from '../../utils/constants';
 import determineIfWantsFuture from '../../utils/determineIfWantsFuture';
 import fireAction from '../../utils/fireAction';
@@ -461,9 +462,9 @@ export function setOrderLocationId(
       (onValidationError && typeof onValidationError === 'function')
     ) {
       /**
-       * apiVersion v2
+       * apiVersion: v2
        */
-      if (get(validateOptions, 'apiVersion') === 'v2') {
+      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
         return dispatch(
           _v2_withCartValidation(
             { location_id: locationId },
@@ -475,7 +476,7 @@ export function setOrderLocationId(
       }
 
       /**
-       * apiVersion v1
+       * apiVersion: v1
        */
       return dispatch(
         _v1_withCartValidation(
@@ -634,14 +635,16 @@ export function setRequestedAt(
       hasItemsInCart &&
       (onValidationError && typeof onValidationError === 'function')
     ) {
-      return dispatch(
-        _withCartValidation(
-          { requested_at: time },
-          onValidationError,
-          setRequestedAtLogic,
-          validateOptions,
-        ),
-      );
+      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
+        return dispatch(
+          _withCartValidation(
+            { requested_at: time },
+            onValidationError,
+            setRequestedAtLogic,
+            validateOptions,
+          ),
+        );
+      }
     }
     /**
      * Otherwise, we proceed with
@@ -676,8 +679,25 @@ export function setServiceType(
       hasItemsInCart &&
       (onValidationError && typeof onValidationError === 'function')
     ) {
+      /**
+       * apiVersion: v2
+       */
+      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
+        return dispatch(
+          _v2_withCartValidation(
+            { service_type: serviceType },
+            onValidationError,
+            setServiceTypeLogic,
+            validateOptions,
+          ),
+        );
+      }
+
+      /**
+       * apiVersion: v1
+       */
       return dispatch(
-        _withCartValidation(
+        _v1_withCartValidation(
           { service_type: serviceType },
           onValidationError,
           setServiceTypeLogic,
@@ -874,7 +894,7 @@ export function attemptReorder(
  Private
 */
 
-export function _buildLineItemsForReorder(
+function _buildLineItemsForReorder(
   brandibbleRef,
   orderLocationId,
   menusById,
@@ -918,7 +938,7 @@ export function _buildLineItemsForReorder(
   });
 }
 
-export function _v2_withCartValidation(
+function _v2_withCartValidation(
   validationHash,
   onValidationError,
   actionCallback,
@@ -1062,7 +1082,7 @@ export function _v2_withCartValidation(
   };
 }
 
-export function _v1_withCartValidation(
+function _v1_withCartValidation(
   validationHash,
   onValidationError,
   actionCallback,

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -382,8 +382,8 @@ export function resolveOrderLocation(brandibble) {
 export function validateCurrentCart(
   brandibble,
   data = {},
-  options = {},
   onValidationError,
+  options = {},
 ) {
   return (dispatch, getState) => {
     /**
@@ -433,7 +433,12 @@ export function validateCurrentCart(
   };
 }
 
-export function validateCurrentOrder(brandibble, data = {}, options = {}) {
+export function validateCurrentOrder(
+  brandibble,
+  data = {},
+  onValidationError,
+  options = {},
+) {
   return (dispatch) => {
     const { orders } = brandibble;
     const order = orders.current();

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -1026,7 +1026,7 @@ function _v2_withCartValidation(
          * If the validation succeeds
          * we dispatch the actionCallback
          */
-        .then(() => callback())
+        .then(callback)
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1066,7 +1066,7 @@ function _v2_withCartValidation(
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(() => callback());
+                return Promise.all(promises).then(callback);
               };
 
               return errorHandler;
@@ -1107,7 +1107,7 @@ function _v2_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(() => callback());
+                  ).then(callback);
                 }
 
                 /**
@@ -1134,7 +1134,7 @@ function _v2_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(() => callback());
+                  ).then(callback);
                 });
               };
 
@@ -1205,7 +1205,7 @@ function _v1_withCartValidation(
          * Otherwise we return null (this is necessary in the case that
          * validateCurrentCart is passed an onValidationError callback)
          */
-        .then(() => callback())
+        .then(callback)
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1240,7 +1240,7 @@ function _v1_withCartValidation(
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(() => callback());
+                return Promise.all(promises).then(callback);
               }
 
               /**
@@ -1277,7 +1277,7 @@ function _v1_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(() => callback());
+                  ).then(callback);
                 }
 
                 /**
@@ -1304,7 +1304,7 @@ function _v1_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(() => callback());
+                  ).then(callback);
                 });
               }
 

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -1152,7 +1152,7 @@ function _v2_withCartValidation(
               return null;
             }
 
-            /** We don't know */
+            /** This error case has not been handled */
             return null;
           };
 

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -381,7 +381,7 @@ export function resolveOrderLocation(brandibble) {
 
 export function validateCurrentCart(
   brandibble,
-  data = {},
+  testChanges = {},
   onValidationError,
   options = {},
 ) {
@@ -427,7 +427,7 @@ export function validateCurrentCart(
 
     const { orders } = brandibble;
     const order = orders.current();
-    const payload = orders.validateCart(order, data, options);
+    const payload = orders.validateCart(order, testChanges, options);
 
     return dispatch(_validateCurrentCart(payload));
   };
@@ -1151,6 +1151,9 @@ function _v2_withCartValidation(
             ) {
               return null;
             }
+
+            /** We don't know */
+            return null;
           };
 
           const errorsWithHandlers = errorsFormatted.map((error) => {

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -377,18 +377,11 @@ export function resolveOrderLocation(brandibble) {
   return dispatch => dispatch(_resolveOrderLocation(payload));
 }
 
-export function validateCurrentCart(
-  brandibble,
-  data = {},
-  testChanges = {},
-  options = {},
-) {
+export function validateCurrentCart(brandibble, data = {}, options = {}) {
   return (dispatch) => {
     const { orders } = brandibble;
     const order = orders.current();
-    const payload = orders
-      .validateCart(order, data, testChanges, options)
-      .then(res => res);
+    const payload = orders.validateCart(order, data, options).then(res => res);
     return dispatch(_validateCurrentCart(payload));
   };
 }

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -994,6 +994,10 @@ function _v2_withCartValidation(
     const ref = get(state, 'ref');
     const { orders } = ref;
     const order = orders.current();
+    const callback =
+      !!actionCallback && typeof actionCallback === 'function'
+        ? dispatch(actionCallback())
+        : Promise.resolve();
 
     const hasValidationHash =
       !!validationHash && typeof validationHash === 'object';
@@ -1017,11 +1021,7 @@ function _v2_withCartValidation(
          * If the validation succeeds
          * we dispatch the actionCallback
          */
-        .then(() => {
-          return !!actionCallback && typeof actionCallback === 'function'
-            ? dispatch(actionCallback())
-            : null;
-        })
+        .then(callback)
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1053,13 +1053,14 @@ function _v2_withCartValidation(
                 const invalidItemsInCart = getInvalidLineItems(
                   invalidItemIds,
                   lineItemsData,
+                  options,
                 );
 
                 const promises = invalidItemsInCart.map(invalidItem =>
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(dispatch(actionCallback()));
+                return Promise.all(promises).then(callback);
               }
 
               /**
@@ -1096,7 +1097,7 @@ function _v2_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(dispatch(actionCallback()));
+                  ).then(callback);
                 }
 
                 /**
@@ -1123,7 +1124,7 @@ function _v2_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(dispatch(actionCallback()));
+                  ).then(callback);
                 });
               }
 
@@ -1164,6 +1165,10 @@ function _v1_withCartValidation(
     const ref = get(state, 'ref');
     const { orders } = ref;
     const order = orders.current();
+    const callback =
+      !!actionCallback && typeof actionCallback === 'function'
+        ? dispatch(actionCallback())
+        : Promise.resolve();
 
     const hasValidationHash =
       !!validationHash && typeof validationHash === 'object';
@@ -1189,11 +1194,7 @@ function _v1_withCartValidation(
          * Otherwise we return null (this is necessary in the case that
          * validateCurrentCart is passed an onValidationError callback)
          */
-        .then(() => {
-          return !!actionCallback && typeof actionCallback === 'function'
-            ? dispatch(actionCallback())
-            : null;
-        })
+        .then(callback)
         /**
          * If the validation throws
          * we return a function that encapsulates
@@ -1228,7 +1229,7 @@ function _v1_withCartValidation(
                   dispatch(removeLineItem(orderRef, invalidItem)),
                 );
 
-                return Promise.all(promises).then(dispatch(actionCallback()));
+                return Promise.all(promises).then(callback);
               }
 
               /**
@@ -1265,7 +1266,7 @@ function _v1_withCartValidation(
                   );
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(dispatch(actionCallback()));
+                  ).then(callback);
                 }
 
                 /**
@@ -1292,7 +1293,7 @@ function _v1_withCartValidation(
 
                   return dispatch(
                     setRequestedAt(orderRef, firstAvailableOrderTime),
-                  ).then(dispatch(actionCallback()));
+                  ).then(callback);
                 });
               }
 

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -928,7 +928,30 @@ export function _withCartValidation(
         .catch((err) => {
           const errors = get(err, 'errors', []);
 
-          if (errors.length) {
+          const errorsFormatted = errors.reduce((formatted, error) => {
+            if (
+              !get(error, 'errorCode') === ErrorCodes.validateCart.invalidItems
+            ) {
+              return formatted.push(error);
+            }
+
+            const existingInvalidItemsHash = formatted.find(
+              formattedError =>
+                get(formattedError, 'errorCode') ===
+                ErrorCodes.validateCart.invalidItems,
+            );
+
+            let invalidItemError;
+            if (existingInvalidItemsHash) {
+            }
+
+            const formattedInvalidItemError = Object.assign(
+              {},
+              { ...error, source: { pointers: [error.source.pointer] } },
+            );
+          }, []);
+
+          if (errorsFormatted.length) {
             const errorHandler = (error) => {
               const errorCode = get(error, 'code');
               const orderRef = get(state, 'session.order.ref');

--- a/src/actions/session/order.js
+++ b/src/actions/session/order.js
@@ -6,7 +6,7 @@ import {
   Asap,
   ErrorCodes,
   WantsFutureReasons,
-  ApiVersions,
+  ApiVersion,
 } from '../../utils/constants';
 import determineIfWantsFuture from '../../utils/determineIfWantsFuture';
 import fireAction from '../../utils/fireAction';
@@ -464,7 +464,7 @@ export function setOrderLocationId(
       /**
        * apiVersion: v2
        */
-      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
+      if (get(validateOptions, 'apiVersion') === ApiVersion.V2) {
         return dispatch(
           _v2_withCartValidation(
             { location_id: locationId },
@@ -635,7 +635,7 @@ export function setRequestedAt(
       hasItemsInCart &&
       (onValidationError && typeof onValidationError === 'function')
     ) {
-      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
+      if (get(validateOptions, 'apiVersion') === ApiVersion.V2) {
         return dispatch(
           _withCartValidation(
             { requested_at: time },
@@ -682,7 +682,7 @@ export function setServiceType(
       /**
        * apiVersion: v2
        */
-      if (get(validateOptions, 'apiVersion') === ApiVersions.V2) {
+      if (get(validateOptions, 'apiVersion') === ApiVersion.V2) {
         return dispatch(
           _v2_withCartValidation(
             { service_type: serviceType },
@@ -975,7 +975,10 @@ function _v2_withCartValidation(
               /**
                * Invalid items in cart
                */
-              if (errorCode === ErrorCodes.validateCart.v2.invalidItemsInCart) {
+              if (
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V2].invalidItems
+              ) {
                 const lineItemsData = get(
                   state,
                   'session.order.lineItemsData',
@@ -998,7 +1001,10 @@ function _v2_withCartValidation(
               /**
                * Location is closed
                */
-              if (errorCode === ErrorCodes.validateCart.v2.locationIsClosed) {
+              if (
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V2].locationIsClosed
+              ) {
                 const allLocationsById = get(
                   state,
                   'data.locations.locationsById',
@@ -1062,7 +1068,8 @@ function _v2_withCartValidation(
                * (not much we can do here apart from notify the customer)
                */
               if (
-                errorCode === ErrorCodes.validateCart.v2.unmetDeliveryMinimum
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V2].unmetDeliveryMinimum
               ) {
                 return null;
               }
@@ -1116,7 +1123,10 @@ function _v1_withCartValidation(
               /**
                * Invalid items in cart
                */
-              if (errorCode === ErrorCodes.validateCart.v1.invalidItems) {
+              if (
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V1].invalidItems
+              ) {
                 const lineItemsData = get(
                   state,
                   'session.order.lineItemsData',
@@ -1139,7 +1149,10 @@ function _v1_withCartValidation(
               /**
                * Location is closed
                */
-              if (errorCode === ErrorCodes.validateCart.v1.locationIsClosed) {
+              if (
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V1].locationIsClosed
+              ) {
                 const allLocationsById = get(
                   state,
                   'data.locations.locationsById',
@@ -1203,7 +1216,8 @@ function _v1_withCartValidation(
                * (not much we can do here apart from notify the customer)
                */
               if (
-                errorCode === ErrorCodes.validateCart.v1.unmetDeliveryMinimum
+                errorCode ===
+                ErrorCodes.validateCart[ApiVersion.V1].unmetDeliveryMinimum
               ) {
                 return () => Promise.resolve();
               }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
-export const ApiVersions = {
+export const ApiVersion = {
   V1: 'v1',
   V2: 'v2',
 };
@@ -19,12 +19,12 @@ export const ErrorCodes = {
     locationIsClosed: 'orders.validate.location_closed',
     invalidItems: 'orders.validate.invalid_items',
     unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
-    [ApiVersions.V1]: {
+    [ApiVersion.V1]: {
       locationIsClosed: 'orders.validate.location_closed',
       invalidItems: 'orders.validate.invalid_items',
       unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
     },
-    [ApiVersions.V2]: {
+    [ApiVersion.V2]: {
       locationIsClosed: 'cart.validate.location_closed',
       invalidItems: 'cart.validate.invalid_cart',
       unmetDeliveryMinimum: '', // Waiting on JC

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,10 +7,23 @@ export const Status = {
 
 export const ErrorCodes = {
   validateCart: {
+    // TO DO: These have been duplicated below (nested under v1)
+    // for cleaner usage within brandibble-redux itself.
+    // I've opted not to remove the legacy formatting just yet,
+    // as I am not sure which host apps are using them.
     locationIsClosed: 'orders.validate.location_closed',
     invalidItems: 'orders.validate.invalid_items',
     unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
-    invalidItemsInCart: 'cart.validate.invalid_cart', // This is the new error code (validate#cart v2)
+    v1: {
+      locationIsClosed: 'orders.validate.location_closed',
+      invalidItems: 'orders.validate.invalid_items',
+      unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
+    },
+    v2: {
+      locationIsClosed: 'cart.validate.location_closed',
+      invalidItems: 'cart.validate.invalid_cart',
+      unmetDeliveryMinimum: '', // Waiting on JC
+    },
   },
 };
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,8 @@
+export const ApiVersions = {
+  V1: 'v1',
+  V2: 'v2',
+};
+
 export const Status = {
   IDLE: 'IDLE',
   PENDING: 'PENDING',
@@ -14,12 +19,12 @@ export const ErrorCodes = {
     locationIsClosed: 'orders.validate.location_closed',
     invalidItems: 'orders.validate.invalid_items',
     unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
-    v1: {
+    [ApiVersions.V1]: {
       locationIsClosed: 'orders.validate.location_closed',
       invalidItems: 'orders.validate.invalid_items',
       unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
     },
-    v2: {
+    [ApiVersions.V2]: {
       locationIsClosed: 'cart.validate.location_closed',
       invalidItems: 'cart.validate.invalid_cart',
       unmetDeliveryMinimum: '', // Waiting on JC

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -27,7 +27,7 @@ export const ErrorCodes = {
     [ApiVersion.V2]: {
       locationIsClosed: 'cart.validate.location_closed',
       invalidItems: 'cart.validate.invalid_cart',
-      unmetDeliveryMinimum: '', // Waiting on JC
+      unmetDeliveryMinimum: 'cart.validate.delivery_minimum',
     },
   },
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -10,6 +10,7 @@ export const ErrorCodes = {
     locationIsClosed: 'orders.validate.location_closed',
     invalidItems: 'orders.validate.invalid_items',
     unmetDeliveryMinimum: 'orders.validate.delivery_minimum',
+    invalidItemsInCart: 'cart.validate.invalid_cart', // This is the new error code (validate#cart v2)
   },
 };
 

--- a/src/utils/formatValidateCartErrors.js
+++ b/src/utils/formatValidateCartErrors.js
@@ -1,5 +1,5 @@
 import get from './get';
-import { ErrorCodes } from './constants';
+import { ApiVersion, ErrorCodes } from './constants';
 
 export default function (errors) {
   if (!errors || !errors.length) return [];
@@ -7,7 +7,9 @@ export default function (errors) {
   return errors.reduce((formattedArray, error) => {
     // If the current error is not of invalidItems
     // We push it into the array as is, and return the formattedArray
-    if (get(error, 'code') !== ErrorCodes.validateCart.invalidItemsInCart) {
+    if (
+      get(error, 'code') !== ErrorCodes.validateCart[ApiVersion.V2].invalidItems
+    ) {
       formattedArray.push(error);
       return formattedArray;
     }
@@ -17,7 +19,7 @@ export default function (errors) {
     const existingInvalidItemsHash = formattedArray.find(
       formattedError =>
         get(formattedError, 'code') ===
-        ErrorCodes.validateCart.invalidItemsInCart,
+        ErrorCodes.validateCart[ApiVersion.V2].invalidItems,
     );
 
     // If we have not formatted our invalidItemsHash

--- a/src/utils/formatValidateCartErrors.js
+++ b/src/utils/formatValidateCartErrors.js
@@ -1,0 +1,43 @@
+import get from './get';
+import { ErrorCodes } from './constants';
+
+export default function (errors) {
+  if (!errors || !errors.length) return [];
+
+  return errors.reduce((formattedArray, error) => {
+    // If the current error is not of invalidItems
+    // We push it into the array as is, and return the formattedArray
+    if (get(error, 'code') !== ErrorCodes.validateCart.invalidItemsInCart) {
+      formattedArray.push(error);
+      return formattedArray;
+    }
+
+    // Otherwise, we can assume the error is an invalitItems error
+    // and check whether we've already formatted our invalid items hash
+    const existingInvalidItemsHash = formattedArray.find(
+      formattedError =>
+        get(formattedError, 'code') ===
+        ErrorCodes.validateCart.invalidItemsInCart,
+    );
+
+    // If we have not formatted our invalidItemsHash
+    // we updated the source.pointer to source.pointers
+    // which is an array of invalid item ids. We add the current invalid item
+    // pointer to the array and return the formattedArray
+    if (!existingInvalidItemsHash) {
+      const formattedInvalidItemError = Object.assign(
+        {},
+        { ...error, source: { pointers: [error.source.pointer] } },
+      );
+
+      formattedArray.push(formattedInvalidItemError);
+      return formattedArray;
+    }
+
+    // Finally, if we have an existing invalidItemsHash
+    // we push the current invalidItem error's pointer into the pointers array
+    // and return the formattedArray
+    existingInvalidItemsHash.source.pointers.push(error.source.pointer);
+    return formattedArray;
+  }, []);
+}

--- a/src/utils/getInvalidLineItems.js
+++ b/src/utils/getInvalidLineItems.js
@@ -1,12 +1,9 @@
 import get from './get';
 
-export default (invalidItems, lineItemsData) =>
-  invalidItems.reduce((invalidItemsFromCart, invalidItem) => {
+export default (invalidItemIds, lineItemsData) =>
+  invalidItemIds.reduce((invalidItemsFromCart, invalidItemId) => {
     lineItemsData
-      .filter(
-        lineItem =>
-          get(lineItem, 'productData.id') === get(invalidItem, 'source.pointer'),
-      )
+      .filter(lineItem => get(lineItem, 'productData.id') === invalidItemId)
       .forEach(lineItem => invalidItemsFromCart.push(lineItem));
     return invalidItemsFromCart;
   }, []);

--- a/src/utils/getInvalidLineItems.js
+++ b/src/utils/getInvalidLineItems.js
@@ -1,9 +1,29 @@
 import get from './get';
+import { ApiVersion } from './constants';
 
-export default (invalidItemIds, lineItemsData) =>
-  invalidItemIds.reduce((invalidItemsFromCart, invalidItemId) => {
+export default (invalidItems, lineItemsData, options) => {
+  /**
+   * apiVersion: v2
+   */
+  if (get(options, 'apiVersion') === ApiVersion.V2) {
+    return invalidItems.reduce((invalidItemsFromCart, invalidItemId) => {
+      lineItemsData
+        .filter(lineItem => get(lineItem, 'productData.id') === invalidItemId)
+        .forEach(lineItem => invalidItemsFromCart.push(lineItem));
+      return invalidItemsFromCart;
+    }, []);
+  }
+
+  /**
+   * apiVersion: v1
+   */
+  return invalidItems.reduce((invalidItemsFromCart, invalidItem) => {
     lineItemsData
-      .filter(lineItem => get(lineItem, 'productData.id') === invalidItemId)
+      .filter(
+        lineItem =>
+          get(lineItem, 'productData.id') === get(invalidItem, 'source.pointer'),
+      )
       .forEach(lineItem => invalidItemsFromCart.push(lineItem));
     return invalidItemsFromCart;
   }, []);
+};

--- a/tests/actions/application.test.js
+++ b/tests/actions/application.test.js
@@ -1,40 +1,40 @@
 /* global describe before it */
 /* eslint one-var-declaration-per-line:1, one-var:1 */
-import { expect } from "chai";
-import find from "lodash.find";
-import configureStore from "redux-mock-store";
-import reduxMiddleware from "config/middleware";
-import { DateTime } from "luxon";
-import { Timezones } from "../../src/utils/constants";
+import { expect } from 'chai';
+import find from 'lodash.find';
+import configureStore from 'redux-mock-store';
+import reduxMiddleware from 'config/middleware';
+import { DateTime } from 'luxon';
+import { Timezones } from '../../src/utils/constants';
 import {
   sendSupportTicket,
   setupBrandibble,
   setupBrandibbleRedux,
   resetApplication,
-  updateInvalidOrderRequestedAt
-} from "actions/application";
-import { setOrderLocationId } from "actions/session/order";
+  updateInvalidOrderRequestedAt,
+} from 'actions/application';
+import { setOrderLocationId } from 'actions/session/order';
 import {
   brandibble,
   stateWithBrandibbleRef,
-  makeUnpersistedOrder
-} from "../config/stubs";
+  makeUnpersistedOrder,
+} from '../config/stubs';
 import {
   stateForOloOrderStubWithValidRequestedAt,
   stateForCateringOrderWithInvalidRequestedAt,
-  stateForCateringOrderWithAsapRequestedAt
-} from "../config/stateStubs";
+  stateForCateringOrderWithAsapRequestedAt,
+} from '../config/stateStubs';
 
 const { PACIFIC } = Timezones;
 
 const mockStore = configureStore(reduxMiddleware);
 
-describe("actions/application", () => {
+describe('actions/application', () => {
   let store;
   let action;
   let actionsCalled;
 
-  describe("setupBrandibble", () => {
+  describe('setupBrandibble', () => {
     before(() => {
       store = mockStore();
       return setupBrandibble(brandibble)(store.dispatch).then(() => {
@@ -42,233 +42,23 @@ describe("actions/application", () => {
       });
     });
 
-    it("should call 2 actions", () => {
+    it('should call 2 actions', () => {
       expect(actionsCalled).to.have.length.of(2);
     });
 
-    it("brandbibble should be online", () => {
-      action = find(actionsCalled, { type: "SETUP_BRANDIBBLE_FULFILLED" });
+    it('brandbibble should be online', () => {
+      action = find(actionsCalled, { type: 'SETUP_BRANDIBBLE_FULFILLED' });
       expect(action).to.exist;
     });
   });
 
-  describe("setupBrandibbleRedux", () => {
+  describe('setupBrandibbleRedux', () => {
     before(() => {
       store = mockStore(stateWithBrandibbleRef);
       return setupBrandibbleRedux(brandibble)(
         store.dispatch,
-        store.getState
+        store.getState,
       ).then(() => {
-        actionsCalled = store.getActions();
-      });
-    });
-
-    it("should call at least 2 actions", () => {
-      expect(actionsCalled).to.have.length.of.at.least(2);
-    });
-
-    it("should have SETUP_BRANDIBBLE_REDUX_PENDING action", () => {
-      action = find(actionsCalled, { type: "SETUP_BRANDIBBLE_REDUX_PENDING" });
-      expect(action).to.exist;
-    });
-
-    it("should have SETUP_BRANDIBBLE_REDUX_FULFILLED action", () => {
-      action = find(actionsCalled, {
-        type: "SETUP_BRANDIBBLE_REDUX_FULFILLED"
-      });
-      expect(action).to.exist;
-    });
-  });
-
-  describe("updateInvalidOrderRequestedAt for olo order with a valid requested at", () => {
-    before(() => {
-      store = mockStore(stateForOloOrderStubWithValidRequestedAt);
-      const order = makeUnpersistedOrder();
-
-      return setOrderLocationId(order, 885)(
-        store.dispatch,
-        store.getState
-      ).then(() => {
-        const todayAsLuxonDateTime = DateTime.fromISO("2019-02-14T20:35:00Z", {
-          zone: PACIFIC
-        });
-        const requestedAtAsLuxonDateTime = DateTime.fromISO(
-          "2019-02-14T20:45:00Z",
-          { zone: PACIFIC }
-        );
-        return updateInvalidOrderRequestedAt({
-          orderRef: order,
-          todayAsLuxonDateTime,
-          requestedAtAsLuxonDateTime
-        })(store.dispatch, store.getState);
-      });
-    });
-
-    it("should not call SET_REQUESTED_AT action", () => {
-      action = find(store.getActions(), { type: "SETUP_REQUESTED_AT" });
-      expect(action).to.not.exist;
-    });
-  });
-
-  describe("updateInvalidOrderRequestedAt for olo order with an invalid requested at", () => {
-    before(() => {
-      store = mockStore(stateForOloOrderStubWithValidRequestedAt);
-      const order = makeUnpersistedOrder();
-
-      return setOrderLocationId(makeUnpersistedOrder(), 885)(
-        store.dispatch,
-        store.getState
-      ).then(() => {
-        const todayAsLuxonDateTime = DateTime.fromISO("2019-02-14T20:35:00Z", {
-          zone: PACIFIC
-        });
-        const requestedAtAsLuxonDateTime = DateTime.fromISO(
-          "2019-02-14T19:00:00Z",
-          { zone: PACIFIC }
-        );
-        return updateInvalidOrderRequestedAt({
-          orderRef: order,
-          todayAsLuxonDateTime,
-          requestedAtAsLuxonDateTime
-        })(store.dispatch, store.getState).then(() => {
-          actionsCalled = store.getActions();
-        });
-      });
-    });
-
-    it("should call at least 4 actions", () => {
-      expect(actionsCalled).to.have.length.of.at.least(4);
-    });
-
-    it("should have SET_REQUESTED_AT_PENDING action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_PENDING" });
-      expect(action).to.exist;
-    });
-
-    it("should have SET_REQUESTED_AT_FULFILLED action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      expect(action).to.exist;
-    });
-
-    it("should set the updated requested at to 'asap'", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      expect(action.payload.order.requestedAt).to.equal("asap");
-    });
-  });
-
-  describe("updateInvalidOrderRequestedAt for catering order with an invalid requested at", () => {
-    before(() => {
-      store = mockStore(stateForCateringOrderWithInvalidRequestedAt);
-      const order = makeUnpersistedOrder();
-
-      return setOrderLocationId(order, 886)(
-        store.dispatch,
-        store.getState
-      ).then(() => {
-        const todayAsLuxonDateTime = DateTime.fromISO("2019-02-14T20:35:00Z", {
-          zone: PACIFIC
-        });
-        const requestedAtAsLuxonDateTime = DateTime.fromISO(
-          "2019-02-14T19:00:00Z",
-          { zone: PACIFIC }
-        );
-
-        return updateInvalidOrderRequestedAt({
-          orderRef: order,
-          todayAsLuxonDateTime,
-          requestedAtAsLuxonDateTime
-        })(store.dispatch, store.getState).then(() => {
-          actionsCalled = store.getActions();
-        });
-      });
-    });
-
-    it("should call at least 4 actions", () => {
-      expect(actionsCalled).to.have.length.of.at.least(4);
-    });
-
-    it("should have SET_REQUESTED_AT_PENDING action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_PENDING" });
-      expect(action).to.exist;
-    });
-
-    it("should have SET_REQUESTED_AT_FULFILLED action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      expect(action).to.exist;
-    });
-
-    it("should set the updated requested at to a valid ISO8601 date string", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      const requestedAtFromISO = DateTime.fromISO(
-        action.payload.order.requestedAt
-      );
-      expect(requestedAtFromISO.isValid).to.be.true;
-    });
-  });
-
-  describe("updateInvalidOrderRequestedAt for catering order with an ASAP requested at", () => {
-    before(() => {
-      store = mockStore(stateForCateringOrderWithAsapRequestedAt);
-      const order = makeUnpersistedOrder();
-
-      return setOrderLocationId(order, 886)(
-        store.dispatch,
-        store.getState
-      ).then(() => {
-        const todayAsLuxonDateTime = DateTime.fromISO("2019-02-16T20:35:00Z", {
-          zone: PACIFIC
-        });
-        const requestedAtAsLuxonDateTime = DateTime.fromISO(
-          "2019-02-16T19:00:00Z",
-          { zone: PACIFIC }
-        );
-
-        return updateInvalidOrderRequestedAt({
-          orderRef: order,
-          todayAsLuxonDateTime,
-          requestedAtAsLuxonDateTime
-        })(store.dispatch, store.getState).then(() => {
-          actionsCalled = store.getActions();
-        });
-      });
-    });
-
-    it("should call at least 4 actions", () => {
-      expect(actionsCalled).to.have.length.of.at.least(4);
-    });
-
-    it("should have SET_REQUESTED_AT_PENDING action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_PENDING" });
-      expect(action).to.exist;
-    });
-
-    it("should have SET_REQUESTED_AT_FULFILLED action", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      expect(action).to.exist;
-    });
-
-    it("should no longer have a requested at of asap", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      expect(action.payload.order.requestedAt).to.not.equal("asap");
-    });
-
-    it("should have an updated requested at as a valid ISO8601 datetime", () => {
-      action = find(actionsCalled, { type: "SET_REQUESTED_AT_FULFILLED" });
-      const requestedAtFromISO = DateTime.fromISO(
-        action.payload.order.requestedAt
-      );
-      expect(requestedAtFromISO.isValid).to.be.true;
-    });
-  });
-
-  describe('sendSupportTicket', () => {
-    before(() => {
-      store = mockStore();
-      return sendSupportTicket(brandibble, {
-        subject: 'help!',
-        body: 'i need avocado!',
-        email: 'dev@sanctuary.computer',
-      })(store.dispatch).then(() => {
         actionsCalled = store.getActions();
       });
     });
@@ -277,49 +67,259 @@ describe("actions/application", () => {
       expect(actionsCalled).to.have.length.of.at.least(2);
     });
 
-    it('should have SEND_SUPPORT_TICKET_PENDING action', () => {
-      action = find(actionsCalled, { type: 'SEND_SUPPORT_TICKET_PENDING' });
+    it('should have SETUP_BRANDIBBLE_REDUX_PENDING action', () => {
+      action = find(actionsCalled, { type: 'SETUP_BRANDIBBLE_REDUX_PENDING' });
       expect(action).to.exist;
     });
 
-    it('should have SEND_SUPPORT_TICKET_FULFILLED action', () => {
-      action = find(actionsCalled, { type: 'SEND_SUPPORT_TICKET_FULFILLED' });
+    it('should have SETUP_BRANDIBBLE_REDUX_FULFILLED action', () => {
+      action = find(actionsCalled, {
+        type: 'SETUP_BRANDIBBLE_REDUX_FULFILLED',
+      });
       expect(action).to.exist;
     });
   });
 
-  describe("resetApplication", () => {
+  describe('updateInvalidOrderRequestedAt for olo order with a valid requested at', () => {
+    before(() => {
+      store = mockStore(stateForOloOrderStubWithValidRequestedAt);
+      const order = makeUnpersistedOrder();
+
+      return setOrderLocationId(order, 885)(
+        store.dispatch,
+        store.getState,
+      ).then(() => {
+        const todayAsLuxonDateTime = DateTime.fromISO('2019-02-14T20:35:00Z', {
+          zone: PACIFIC,
+        });
+        const requestedAtAsLuxonDateTime = DateTime.fromISO(
+          '2019-02-14T20:45:00Z',
+          { zone: PACIFIC },
+        );
+        return updateInvalidOrderRequestedAt({
+          orderRef: order,
+          todayAsLuxonDateTime,
+          requestedAtAsLuxonDateTime,
+        })(store.dispatch, store.getState);
+      });
+    });
+
+    it('should not call SET_REQUESTED_AT action', () => {
+      action = find(store.getActions(), { type: 'SETUP_REQUESTED_AT' });
+      expect(action).to.not.exist;
+    });
+  });
+
+  describe('updateInvalidOrderRequestedAt for olo order with an invalid requested at', () => {
+    before(() => {
+      store = mockStore(stateForOloOrderStubWithValidRequestedAt);
+      const order = makeUnpersistedOrder();
+
+      return setOrderLocationId(makeUnpersistedOrder(), 885)(
+        store.dispatch,
+        store.getState,
+      ).then(() => {
+        const todayAsLuxonDateTime = DateTime.fromISO('2019-02-14T20:35:00Z', {
+          zone: PACIFIC,
+        });
+        const requestedAtAsLuxonDateTime = DateTime.fromISO(
+          '2019-02-14T19:00:00Z',
+          { zone: PACIFIC },
+        );
+        return updateInvalidOrderRequestedAt({
+          orderRef: order,
+          todayAsLuxonDateTime,
+          requestedAtAsLuxonDateTime,
+        })(store.dispatch, store.getState).then(() => {
+          actionsCalled = store.getActions();
+        });
+      });
+    });
+
+    it('should call at least 4 actions', () => {
+      expect(actionsCalled).to.have.length.of.at.least(4);
+    });
+
+    it('should have SET_REQUESTED_AT_PENDING action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_PENDING' });
+      expect(action).to.exist;
+    });
+
+    it('should have SET_REQUESTED_AT_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      expect(action).to.exist;
+    });
+
+    it("should set the updated requested at to 'asap'", () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      expect(action.payload.order.requestedAt).to.equal('asap');
+    });
+  });
+
+  describe('updateInvalidOrderRequestedAt for catering order with an invalid requested at', () => {
+    before(() => {
+      store = mockStore(stateForCateringOrderWithInvalidRequestedAt);
+      const order = makeUnpersistedOrder();
+
+      return setOrderLocationId(order, 886)(
+        store.dispatch,
+        store.getState,
+      ).then(() => {
+        const todayAsLuxonDateTime = DateTime.fromISO('2019-02-14T20:35:00Z', {
+          zone: PACIFIC,
+        });
+        const requestedAtAsLuxonDateTime = DateTime.fromISO(
+          '2019-02-14T19:00:00Z',
+          { zone: PACIFIC },
+        );
+
+        return updateInvalidOrderRequestedAt({
+          orderRef: order,
+          todayAsLuxonDateTime,
+          requestedAtAsLuxonDateTime,
+        })(store.dispatch, store.getState).then(() => {
+          actionsCalled = store.getActions();
+        });
+      });
+    });
+
+    it('should call at least 4 actions', () => {
+      expect(actionsCalled).to.have.length.of.at.least(4);
+    });
+
+    it('should have SET_REQUESTED_AT_PENDING action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_PENDING' });
+      expect(action).to.exist;
+    });
+
+    it('should have SET_REQUESTED_AT_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      expect(action).to.exist;
+    });
+
+    it('should set the updated requested at to a valid ISO8601 date string', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      const requestedAtFromISO = DateTime.fromISO(
+        action.payload.order.requestedAt,
+      );
+      expect(requestedAtFromISO.isValid).to.be.true;
+    });
+  });
+
+  describe('updateInvalidOrderRequestedAt for catering order with an ASAP requested at', () => {
+    before(() => {
+      store = mockStore(stateForCateringOrderWithAsapRequestedAt);
+      const order = makeUnpersistedOrder();
+
+      return setOrderLocationId(order, 886)(
+        store.dispatch,
+        store.getState,
+      ).then(() => {
+        const todayAsLuxonDateTime = DateTime.fromISO('2019-02-16T20:35:00Z', {
+          zone: PACIFIC,
+        });
+        const requestedAtAsLuxonDateTime = DateTime.fromISO(
+          '2019-02-16T19:00:00Z',
+          { zone: PACIFIC },
+        );
+
+        return updateInvalidOrderRequestedAt({
+          orderRef: order,
+          todayAsLuxonDateTime,
+          requestedAtAsLuxonDateTime,
+        })(store.dispatch, store.getState).then(() => {
+          actionsCalled = store.getActions();
+        });
+      });
+    });
+
+    it('should call at least 4 actions', () => {
+      expect(actionsCalled).to.have.length.of.at.least(4);
+    });
+
+    it('should have SET_REQUESTED_AT_PENDING action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_PENDING' });
+      expect(action).to.exist;
+    });
+
+    it('should have SET_REQUESTED_AT_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      expect(action).to.exist;
+    });
+
+    it('should no longer have a requested at of asap', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      expect(action.payload.order.requestedAt).to.not.equal('asap');
+    });
+
+    it('should have an updated requested at as a valid ISO8601 datetime', () => {
+      action = find(actionsCalled, { type: 'SET_REQUESTED_AT_FULFILLED' });
+      const requestedAtFromISO = DateTime.fromISO(
+        action.payload.order.requestedAt,
+      );
+      expect(requestedAtFromISO.isValid).to.be.true;
+    });
+  });
+
+  // describe('sendSupportTicket', () => {
+  //   before(() => {
+  //     store = mockStore();
+  //     return sendSupportTicket(brandibble, {
+  //       subject: 'help!',
+  //       body: 'i need avocado!',
+  //       email: 'dev@sanctuary.computer',
+  //     })(store.dispatch).then(() => {
+  //       actionsCalled = store.getActions();
+  //     });
+  //   });
+
+  //   it('should call at least 2 actions', () => {
+  //     expect(actionsCalled).to.have.length.of.at.least(2);
+  //   });
+
+  //   it('should have SEND_SUPPORT_TICKET_PENDING action', () => {
+  //     action = find(actionsCalled, { type: 'SEND_SUPPORT_TICKET_PENDING' });
+  //     expect(action).to.exist;
+  //   });
+
+  //   it('should have SEND_SUPPORT_TICKET_FULFILLED action', () => {
+  //     action = find(actionsCalled, { type: 'SEND_SUPPORT_TICKET_FULFILLED' });
+  //     expect(action).to.exist;
+  //   });
+  // });
+
+  describe('resetApplication', () => {
     before(() => {
       store = mockStore(stateWithBrandibbleRef);
       return resetApplication(brandibble)(store.dispatch, store.getState).then(
         () => {
           actionsCalled = store.getActions();
-        }
+        },
       );
     });
 
-    it("should call at least 4 actions", () => {
+    it('should call at least 4 actions', () => {
       expect(actionsCalled).to.have.length.of.at.least(4);
     });
 
-    it("should have the RESET_APPLICATION_PENDING action", () => {
-      action = find(actionsCalled, { type: "RESET_APPLICATION_PENDING" });
+    it('should have the RESET_APPLICATION_PENDING action', () => {
+      action = find(actionsCalled, { type: 'RESET_APPLICATION_PENDING' });
       expect(action).to.exist;
     });
 
-    it("should have the RESET_APPLICATION_FULFILLED action", () => {
-      action = find(actionsCalled, { type: "RESET_APPLICATION_FULFILLED" });
+    it('should have the RESET_APPLICATION_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'RESET_APPLICATION_FULFILLED' });
       expect(action).to.exist;
     });
 
-    it("should have SETUP_BRANDIBBLE_REDUX_PENDING action", () => {
-      action = find(actionsCalled, { type: "SETUP_BRANDIBBLE_REDUX_PENDING" });
+    it('should have SETUP_BRANDIBBLE_REDUX_PENDING action', () => {
+      action = find(actionsCalled, { type: 'SETUP_BRANDIBBLE_REDUX_PENDING' });
       expect(action).to.exist;
     });
 
-    it("should have SETUP_BRANDIBBLE_REDUX_FULFILLED action", () => {
+    it('should have SETUP_BRANDIBBLE_REDUX_FULFILLED action', () => {
       action = find(actionsCalled, {
-        type: "SETUP_BRANDIBBLE_REDUX_FULFILLED"
+        type: 'SETUP_BRANDIBBLE_REDUX_FULFILLED',
       });
       expect(action).to.exist;
     });

--- a/tests/actions/session/order.test.js
+++ b/tests/actions/session/order.test.js
@@ -481,6 +481,129 @@ describe('actions/session/order', () => {
     });
   });
 
+  describe('validateCurrentCart with errorHandlers v1', () => {
+    before(() => {
+      store = mockStore(stateWithBrandibbleRef);
+      const order = makeUnpersistedOrder('pickup');
+      const onValidationErrorCallback = f => f;
+
+      return fetchMenu(brandibble, { locationId: SAMPLE_MENU_LOCATION_ID })(
+        store.dispatch,
+        store.getState,
+      ).then(({ value: { menu } }) => {
+        const product = getNonConfigurableMenuItem(menu);
+        order.cart.addLineItem(product, 1, product.id);
+
+        return setOrderLocationId(order, SAMPLE_MENU_LOCATION_ID)(
+          store.dispatch,
+          store.getState,
+        ).then(() => {
+          return setOrderAddress(order, addressStub)(store.dispatch).then(
+            () => {
+              return bindCustomerToOrder(order, authResponseStub)(
+                store.dispatch,
+              ).then(() => {
+                return setPaymentMethod(order, 'credit', cardStub)(
+                  store.dispatch,
+                ).then(() => {
+                  store.clearActions();
+                  return validateCurrentCart(
+                    brandibble,
+                    null,
+                    onValidationErrorCallback,
+                  )(store.dispatch, store.getState).then(() => {
+                    actionsCalled = store.getActions();
+                  });
+                });
+              });
+            },
+          );
+        });
+      });
+    });
+
+    it('should call 2 actions', () => {
+      expect(actionsCalled).to.have.length.of(2);
+    });
+
+    it('should have VALIDATE_CURRENT_CART_PENDING action', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_PENDING' });
+      expect(action).to.exist;
+    });
+
+    it('should have VALIDATE_CURRENT_CART_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_FULFILLED' });
+      expect(action).to.exist;
+    });
+
+    it('should have a payload', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_FULFILLED' });
+      expect(action).to.have.a.property('payload');
+    });
+  });
+
+  describe('validateCurrentCart with errorHandlers v2', () => {
+    before(() => {
+      store = mockStore(stateWithBrandibbleRef);
+      const order = makeUnpersistedOrder('pickup');
+      const onValidationErrorCallback = f => f;
+
+      return fetchMenu(brandibble, { locationId: SAMPLE_MENU_LOCATION_ID })(
+        store.dispatch,
+        store.getState,
+      ).then(({ value: { menu } }) => {
+        const product = getNonConfigurableMenuItem(menu);
+        order.cart.addLineItem(product, 1, product.id);
+
+        return setOrderLocationId(order, SAMPLE_MENU_LOCATION_ID)(
+          store.dispatch,
+          store.getState,
+        ).then(() => {
+          return setOrderAddress(order, addressStub)(store.dispatch).then(
+            () => {
+              return bindCustomerToOrder(order, authResponseStub)(
+                store.dispatch,
+              ).then(() => {
+                return setPaymentMethod(order, 'credit', cardStub)(
+                  store.dispatch,
+                ).then(() => {
+                  store.clearActions();
+                  return validateCurrentCart(
+                    brandibble,
+                    null,
+                    onValidationErrorCallback,
+                    { apiVersion: 'v2' },
+                  )(store.dispatch, store.getState).then(() => {
+                    actionsCalled = store.getActions();
+                  });
+                });
+              });
+            },
+          );
+        });
+      });
+    });
+
+    it('should call 2 actions', () => {
+      expect(actionsCalled).to.have.length.of(2);
+    });
+
+    it('should have VALIDATE_CURRENT_CART_PENDING action', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_PENDING' });
+      expect(action).to.exist;
+    });
+
+    it('should have VALIDATE_CURRENT_CART_FULFILLED action', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_FULFILLED' });
+      expect(action).to.exist;
+    });
+
+    it('should have a payload', () => {
+      action = find(actionsCalled, { type: 'VALIDATE_CURRENT_CART_FULFILLED' });
+      expect(action).to.have.a.property('payload');
+    });
+  });
+
   describe('validateCurrentOrder', () => {
     before(() => {
       store = mockStore(stateWithBrandibbleRef);

--- a/tests/actions/session/order.test.js
+++ b/tests/actions/session/order.test.js
@@ -456,11 +456,12 @@ describe('actions/session/order', () => {
                   store.dispatch,
                 ).then(() => {
                   store.clearActions();
-                  return validateCurrentCart(brandibble)(store.dispatch).then(
-                    () => {
-                      actionsCalled = store.getActions();
-                    },
-                  );
+                  return validateCurrentCart(brandibble)(
+                    store.dispatch,
+                    store.getState,
+                  ).then(() => {
+                    actionsCalled = store.getActions();
+                  });
                 });
               });
             },

--- a/tests/utils.js/formatValidateCartErrors.test.js
+++ b/tests/utils.js/formatValidateCartErrors.test.js
@@ -1,0 +1,93 @@
+/* global describe it */
+import { expect } from 'chai';
+import formatValidateCartErrors from '../../src/utils/formatValidateCartErrors';
+
+describe('utils/formatValidateCartErrors', () => {
+  it('It should return an empty array if no arguments were passed', () => {
+    const formattedCartErrors = formatValidateCartErrors();
+    expect(formattedCartErrors).to.be.an('array').that.is.empty;
+  });
+
+  it('It should return an array of errors untouched if the error array did not contain invalidItem errors', () => {
+    const testErrors = [
+      {
+        code: 'cart.validate.invalid_service_type',
+        source: {
+          pointer: 'service_type',
+        },
+        title: "Service type must be one of 'pickup' or 'delivery'.",
+      },
+      {
+        code: 'cart.validate.invalid_service_type',
+        source: {
+          pointer: 'service_type',
+        },
+        title: "Service type must be one of 'pickup' or 'delivery'.",
+      },
+    ];
+
+    const formattedCartErrors = formatValidateCartErrors(testErrors);
+
+    expect(formattedCartErrors[0].code).to.equal(testErrors[0].code);
+    expect(formattedCartErrors[0].source.pointer).to.equal(
+      testErrors[0].source.pointer,
+    );
+    expect(formattedCartErrors[0].title).to.equal(testErrors[0].title);
+    expect(formattedCartErrors[1].code).to.equal(testErrors[1].code);
+    expect(formattedCartErrors[1].source.pointer).to.equal(
+      testErrors[1].source.pointer,
+    );
+    expect(formattedCartErrors[1].title).to.equal(testErrors[1].title);
+  });
+
+  it('It should return an array of errors with invalidItemErrors correctly formatted', () => {
+    const testErrors = [
+      {
+        code: 'cart.validate.invalid_service_type',
+        source: {
+          pointer: 'service_type',
+        },
+        title: "Service type must be one of 'pickup' or 'delivery'.",
+      },
+      {
+        code: 'cart.validate.invalid_service_type',
+        source: {
+          pointer: 'service_type',
+        },
+        title: "Service type must be one of 'pickup' or 'delivery'.",
+      },
+      {
+        code: 'cart.validate.invalid_cart',
+        source: {
+          pointer: 19708,
+        },
+        title: 'This item is invalid',
+      },
+      {
+        code: 'cart.validate.invalid_cart',
+        source: {
+          pointer: 19709,
+        },
+        title: 'This item is invalid',
+      },
+    ];
+
+    const formattedCartErrors = formatValidateCartErrors(testErrors);
+    expect(formattedCartErrors).to.have.length.of(3);
+    expect(formattedCartErrors[0].code).to.equal(testErrors[0].code);
+    expect(formattedCartErrors[0].source.pointer).to.equal(
+      testErrors[0].source.pointer,
+    );
+    expect(formattedCartErrors[0].title).to.equal(testErrors[0].title);
+    expect(formattedCartErrors[1].code).to.equal(testErrors[1].code);
+    expect(formattedCartErrors[1].source.pointer).to.equal(
+      testErrors[1].source.pointer,
+    );
+    expect(formattedCartErrors[1].title).to.equal(testErrors[1].title);
+    expect(formattedCartErrors[2].code).to.equal(testErrors[2].code);
+    expect(formattedCartErrors[2].source.pointers)
+      .to.be.an('array')
+      .that.includes(19708, 19709);
+    expect(formattedCartErrors[2].title).to.equal(testErrors[2].title);
+  });
+});


### PR DESCRIPTION
This is the first step in updating the cartValidation logic:

In this PR:
- I removed the testChanges argument from validateCart because It wasn't doing (never gets passed to Brandibble Redux)
- Update withCartValidation to loops through each error, and returns a hash with the error, and proceed function, which gets passed to onValidationError as an array of hashed ```[{error: error, proceed: () => () }, ...]```
- Added a utility to format invalidItemErrors into a single hash, as they are currently returned as individual error hashes

TODO:
- JC seems to have changed the errorCodes for the errors we handle on validateCart v2. I was able to recreate and update the errorCode for invalidItems, but haven't managed to recreate the others. We'll need to do this in order to proceed.
- Need to update validateCart to accept an onValidationError callback, and run the logic inside of withCartValidation

Questions:
- Backwards compatibility is getting harrier and harrier. Do you foresee anything in here that would break on v1?
- Ellis and I have been trying to recreate a series of cartValidation errors that we can test this logic against, but it doesn't seem like validateCart v2 returns multiple errors unless they are of the same type (e.g. invalidItems). Ellis is capturing this issue and will share with you/JC. 